### PR TITLE
Added setting for quick craft amount

### DIFF
--- a/locale/en/CursorEnhancements.cfg
+++ b/locale/en/CursorEnhancements.cfg
@@ -15,3 +15,4 @@ cen-auto-ghost-cursor=When the item in your cursor runs out, replace it with the
 
 [mod-setting-name]
 cen-auto-ghost-cursor=Automatic ghost cursor
+cen-quick-craft-count=Quick-craft count

--- a/scripts/quick-craft.lua
+++ b/scripts/quick-craft.lua
@@ -35,7 +35,8 @@ local function on_quick_craft(e)
     return
   end
 
-  player.begin_crafting({ recipe = recipe, count = 5 })
+  local craft_count = player.mod_settings["quick-craft-count"].value
+  player.begin_crafting({ recipe = recipe, count = craft_count })
 end
 
 local quick_craft = {}

--- a/scripts/quick-craft.lua
+++ b/scripts/quick-craft.lua
@@ -35,7 +35,7 @@ local function on_quick_craft(e)
     return
   end
 
-  local craft_count = player.mod_settings["quick-craft-count"].value
+  local craft_count = player.mod_settings["cen-quick-craft-count"].value --[[@as uint]]
   player.begin_crafting({ recipe = recipe, count = craft_count })
 end
 

--- a/settings.lua
+++ b/settings.lua
@@ -7,7 +7,7 @@ data:extend({
   },
   {
     type = "int-setting",
-    name = "quick-craft-count",
+    name = "cen-quick-craft-count",
     setting_type = "runtime-per-user",
     minimum_value = 1,
     maximum_value = 200,

--- a/settings.lua
+++ b/settings.lua
@@ -5,4 +5,12 @@ data:extend({
     setting_type = "runtime-per-user",
     default_value = true,
   },
+  {
+    type = "int-setting",
+    name = "quick-craft-count",
+    setting_type = "runtime-per-user",
+    minimum_value = 1,
+    maximum_value = 200,
+    default_value = 5,
+  },
 })


### PR DESCRIPTION
I personally like quick craft to only do 1 item at a time. I mainly use it for queuing up more crafting buildings and find that 5 at a time is too many, especially with modded crafting buildings.