### PR TITLE
FR: Add history for item recall

### DIFF
--- a/scripts/migrations.lua
+++ b/scripts/migrations.lua
@@ -8,6 +8,12 @@ local migrations = {
   ["2.2.0"] = function()
     storage.subgroups = nil
   end,
+  ["2.2.2"] = function()
+    storage.item_history = {}
+    storage.item_update_tick = {}
+    storage.history_index = {}
+    storage.last_item = nil
+  end,
 }
 
 local function on_configuration_changed(e)

--- a/scripts/recall-last-item.lua
+++ b/scripts/recall-last-item.lua
@@ -1,5 +1,7 @@
 local util = require("scripts.util")
 
+local MAX_HISTORY_SIZE = 10
+
 --- @param e EventData.CustomInputEvent
 local function on_recall_last_item(e)
   local player = game.get_player(e.player_index)
@@ -7,12 +9,26 @@ local function on_recall_last_item(e)
     return
   end
 
-  local last_item = storage.last_item[e.player_index]
-  if not last_item then
+  local history = storage.item_history[e.player_index]
+  local index = storage.history_index[e.player_index]
+
+  if not (history and index) then
     return
   end
 
-  util.set_cursor(player, last_item)
+  local cursor_item = util.get_cursor_item(player)
+  if cursor_item and index == 1 then
+    index = 2
+  end
+
+  local item = history[index]
+  if not item then
+    return
+  end
+
+  util.set_cursor(player, item)
+  storage.history_index[e.player_index] = (index % #history) + 1
+  storage.item_update_tick[e.player_index] = e.tick
 end
 
 --- @param e EventData.on_player_cursor_stack_changed
@@ -22,19 +38,42 @@ local function on_player_cursor_stack_changed(e)
     return
   end
 
-  local item = util.get_cursor_item(player)
-  if not item then
+  if (e.tick == storage.item_update_tick[e.player_index]) then
     return
   end
 
-  storage.last_item[e.player_index] = item
+  local history = storage.item_history[e.player_index] or {}
+  storage.item_history[e.player_index] = history
+  storage.history_index[e.player_index] = 1
+
+  local cursor_item = util.get_cursor_item(player)
+  if not cursor_item then
+    return
+  end
+
+  for i, history_item in pairs(history) do
+    if serpent.line(cursor_item) == serpent.line(history_item) then
+      table.insert(history, 1, table.remove(history, i))
+      return
+    end
+  end
+
+  table.insert(history, 1, cursor_item)
+
+  if #history > MAX_HISTORY_SIZE then
+    table.remove(history)
+  end
 end
 
 local recall_last_item = {}
 
 recall_last_item.on_init = function()
-  --- @type table<uint, ItemWithQualityID?>
-  storage.last_item = {}
+  --- @type table<uint, table<number, ItemWithQualityID>>
+  storage.item_history = {}
+  --- @type table<uint, number>
+  storage.item_update_tick = {}
+  --- @type table<uint, number>
+  storage.history_index = {}
 end
 
 recall_last_item.events = {


### PR DESCRIPTION
Adds history to item recall feature.

Basically repeatedly pressing `shift-q` will cycle up to 10 previously selected items.

I remember missing this functionality when I needed to copy items from logistic section to a constant combinator.

Demo:

https://github.com/user-attachments/assets/5475853a-0bb6-4398-b08b-3350e16ef57c

